### PR TITLE
Avoid 'calling set on destroyed object' errors by checking if the component is destroyed or being destroyed

### DIFF
--- a/addon/components/m-image.js
+++ b/addon/components/m-image.js
@@ -17,8 +17,10 @@ export default Ember.Component.extend({
 
   // @private
   _updateState(css, src) {
-    this.set('imageStateCss', css);
-    this.set('_imageSrc', src);
+    if (!this.get('isDestroyed') && !this.get('isDestroying')) {
+      this.set('imageStateCss', css);
+      this.set('_imageSrc', src);
+    }
   },
 
   // @private


### PR DESCRIPTION
This was causing non-deterministic build failures in an ember 3.5 app. Only a problem in tests since Ember may invalidate the layout before `_updateState` gets called.

Thanks!